### PR TITLE
Fix PlayerConfigurationExample

### DIFF
--- a/Example/PlayerConfigurationExample.swift
+++ b/Example/PlayerConfigurationExample.swift
@@ -20,7 +20,7 @@ struct PlayerConfigurationExample: PlayerConfiguration {
     let rateObservingTickTime: TimeInterval = 0.3
 
     // General Audio preferences
-    let preferredTimescale = CMTimeScale(NSEC_PER_SEC)
+    let preferedTimescale = CMTimeScale(NSEC_PER_SEC)
     let periodicPlayingTime: CMTime
     let audioSessionCategory = AVAudioSession.Category.playback
 


### PR DESCRIPTION
Fix PlayerConfigurationExample.swift

  * Your punchline must be under a category in the [X.X.X] section
  * If the [X.X.X] not exist, create it above the last release section
  * Try to use category already present in the file
  * Add reference to an issue if necessary
