### PR TITLE
Improve round times for Reached End Time event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ---
-## [1.7.2]
+## [X.X.X]
 * Improvement:
 	* Improve round times in `hasReallyReachedEndTime` func at `PlaybackObservingService.swift`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ All notable changes to this project will be documented in this file.
 ## [1.3.3]
 * Feature:
 	* Seek media with a given offset
-	* Seek position is bounded between 0 and current media end time
+	* Seek position is bounded between 0 and current media end time 
 * Demo:
 	* New simple video example
 * Breaking change:
@@ -179,7 +179,7 @@ All notable changes to this project will be documented in this file.
 ## [1.0.0]
 * Breaking changes:
 	* `load(media:autostart:position:)` replaces `loadMedia(media:autostart:position:)`
-	* iOS 10.0+ requirement
+	* iOS 10.0+ requirement 
 * Feature:
 	* Update to swift 4.2
 * Improvement:
@@ -221,10 +221,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.13.0]
 * Feature:
-	* Enable/Disable loop mode on current media
+	* Enable/Disable loop mode on current media 
 * Fix:
 	* Update NowPlayingInfo time at the right moment when item play reach end time
-	* Update init media documentation
+	* Update init media documentation 
 
 ## [0.12.0]
 * Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [1.7.2]
+* Improvement:
+	* Improve round times in `hasReallyReachedEndTime` func at `PlaybackObservingService.swift`
+
 ## [1.7.1]
 * Fix:
 	* Spm install
@@ -76,7 +80,7 @@ All notable changes to this project will be documented in this file.
 ## [1.3.3]
 * Feature:
 	* Seek media with a given offset
-	* Seek position is bounded between 0 and current media end time 
+	* Seek position is bounded between 0 and current media end time
 * Demo:
 	* New simple video example
 * Breaking change:
@@ -175,7 +179,7 @@ All notable changes to this project will be documented in this file.
 ## [1.0.0]
 * Breaking changes:
 	* `load(media:autostart:position:)` replaces `loadMedia(media:autostart:position:)`
-	* iOS 10.0+ requirement 
+	* iOS 10.0+ requirement
 * Feature:
 	* Update to swift 4.2
 * Improvement:
@@ -217,10 +221,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.13.0]
 * Feature:
-	* Enable/Disable loop mode on current media 
+	* Enable/Disable loop mode on current media
 * Fix:
 	* Update NowPlayingInfo time at the right moment when item play reach end time
-	* Update init media documentation 
+	* Update init media documentation
 
 ## [0.12.0]
 * Features:

--- a/Sources/Core/Services/PlaybackObservingService.swift
+++ b/Sources/Core/Services/PlaybackObservingService.swift
@@ -80,7 +80,7 @@ final class ModernAVPlayerPlaybackObservingService: PlaybackObservingService {
         /// is not so accurate according to duration
         /// added +1 make sure about the computation
         let currentTime = player.currentTime().seconds + 1
-        return currentTime >= duration
+        return currentTime.rounded() >= duration.rounded()
     }
     
     @objc


### PR DESCRIPTION
Hello! 
Faced with the issue for `0.06` seconds at `duration` and `currentTime` comparison. 
Now working fine with different durations.

What changed: 
Improved round times in `hasReallyReachedEndTime` func at `PlaybackObservingService.swift`