### PR TITLE
feat: add accurate seek api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 ## [X.X.X]
- * Feature:
- 	* Accurate seek api
+* Feature:
+	* Accurate seek api
 
 ## [1.7.3]
- * Fix:
- 	* Resume audio on device background mode
- * Breaking change:
- 	* `PlayerConfiguration` has a new `AVAudioSessionCategoryOptions` attribute
+* Fix:
+	* Resume audio on device background mode
+* Breaking change:
+	* `PlayerConfiguration` has a new `AVAudioSessionCategoryOptions` attribute
 
 ## [1.7.2]
 * Feature:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ---
-## [1.7.3]
-* Fix:
-	* Resume audio on device background mode
-* Breaking change:
-	* `PlayerConfiguration` has a new `AVAudioSessionCategoryOptions` attribute
-
+## [X.X.X]
+* Feature:
+	* Accurate seek api
+    
 ## [1.7.2]
 * Feature:
 	* tvOS support [@yaroslavlvov]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 ## [X.X.X]
-* Feature:
-	* Accurate seek api
-    
+ * Feature:
+ 	* Accurate seek api
+
+## [1.7.3]
+ * Fix:
+ 	* Resume audio on device background mode
+ * Breaking change:
+ 	* `PlayerConfiguration` has a new `AVAudioSessionCategoryOptions` attribute
+
 ## [1.7.2]
 * Feature:
 	* tvOS support [@yaroslavlvov]

--- a/Example/RemoteCommandExample.swift
+++ b/Example/RemoteCommandExample.swift
@@ -126,7 +126,7 @@ public struct RemoteCommandFactoryExample {
             guard let e = event as? MPChangePlaybackPositionCommandEvent
                 else { return .commandFailed }
             let position = e.positionTime
-            self.player.seek(position: position)
+            self.player.seek(position: position, isAccurate: false)
             return .success
         }
         command.addTarget(handler: handler)
@@ -145,7 +145,7 @@ public struct RemoteCommandFactoryExample {
                 else { return .commandFailed }
 
             let position = max(self.player.currentTime - skipTime, 0)
-            self.player.seek(position: position)
+            self.player.seek(position: position, isAccurate: false)
             return .success
         }
         command.addTarget(handler: handler)
@@ -164,7 +164,7 @@ public struct RemoteCommandFactoryExample {
                 else { return .commandFailed }
 
             let position = self.player.currentTime + skipTime
-            self.player.seek(position: position)
+            self.player.seek(position: position, isAccurate: false)
             return .success
         }
         command.addTarget(handler: handler)

--- a/Sources/Core/Components/PlayerCommand.swift
+++ b/Sources/Core/Components/PlayerCommand.swift
@@ -30,6 +30,6 @@ public protocol PlayerCommand {
     func load(media: PlayerMedia, autostart: Bool, position: Double?)
     func pause()
     func play()
-    func seek(position: Double)
+    func seek(position: Double, isAccurate: Bool)
     func stop()
 }

--- a/Sources/Core/Components/PlayerContext.swift
+++ b/Sources/Core/Components/PlayerContext.swift
@@ -146,14 +146,14 @@ final class ModernAVPlayerContext: NSObject, PlayerContext {
         state.pause()
     }
 
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         guard let item = currentItem
             else { unaivalableCommand(reason: .loadMediaFirst); return }
 
         let seekService = ModernAVPlayerSeekService(preferredTimescale: config.preferredTimescale)
         let seekPosition = seekService.boundedPosition(position, item: item)
         if let boundedPosition = seekPosition.value {
-            state.seek(position: boundedPosition)
+            state.seek(position: boundedPosition, isAccurate: isAccurate)
         } else if let reason = seekPosition.reason {
             unaivalableCommand(reason: reason)
         } else {
@@ -161,9 +161,9 @@ final class ModernAVPlayerContext: NSObject, PlayerContext {
         }
     }
 
-    func seek(offset: Double) {
+    func seek(offset: Double, isAccurate: Bool) {
         let position = currentTime + offset
-        seek(position: position)
+        seek(position: position, isAccurate: isAccurate)
     }
 
     func stop() {

--- a/Sources/Core/Components/RemoteCommand/ModernAVPlayerRemoteCommandFactory.swift
+++ b/Sources/Core/Components/RemoteCommand/ModernAVPlayerRemoteCommandFactory.swift
@@ -165,7 +165,7 @@ public class ModernAVPlayerRemoteCommandFactory {
             
             let position = e.positionTime
             ModernAVPlayerLogger.instance.log(message: "Remote command: seek to \(position)", domain: .service)
-            self.player.seek(position: position)
+            self.player.seek(position: position, isAccurate: false)
             return .success
         }
         command.addTarget(handler: handler)
@@ -191,7 +191,7 @@ public class ModernAVPlayerRemoteCommandFactory {
             
             ModernAVPlayerLogger.instance.log(message: "Remote command: skipBackward", domain: .service)
             let position = max(self.player.currentTime - skipTime, 0)
-            self.player.seek(position: position)
+            self.player.seek(position: position, isAccurate: false)
             return .success
         }
         command.addTarget(handler: handler)
@@ -217,7 +217,7 @@ public class ModernAVPlayerRemoteCommandFactory {
             
             ModernAVPlayerLogger.instance.log(message: "Remote command: skipForward", domain: .service)
             let position = self.player.currentTime + skipTime
-            self.player.seek(position: position)
+            self.player.seek(position: position, isAccurate: false)
             return .success
         }
         command.addTarget(handler: handler)

--- a/Sources/Core/ModernAVPlayer.swift
+++ b/Sources/Core/ModernAVPlayer.swift
@@ -105,6 +105,7 @@ public final class ModernAVPlayer: NSObject, ModernAVPlayerExposable {
     /// - Note: position is bounded between 0 and end time or available ranges, resulting seek position may differ slightly for efficiency
     /// - parameter position: time to seek
     ///
+    @available(*, deprecated, message: "use func seek(position: Double, isAccurate: Bool = false) instead")
     public func seek(position: Double) {
         context.seek(position: position, isAccurate: false)
     }
@@ -127,6 +128,7 @@ public final class ModernAVPlayer: NSObject, ModernAVPlayerExposable {
     /// - Note: this method compute position then call then seek(position:), resulting seek position may differ slightly for efficiency
     /// - parameter offset: offset to apply
     ///
+    @available(*, deprecated, message: "use func seek(offset: Double, isAccurate: Bool = false) instead")
     public func seek(offset: Double) {
         context.seek(offset: offset, isAccurate: false)
     }

--- a/Sources/Core/ModernAVPlayer.swift
+++ b/Sources/Core/ModernAVPlayer.swift
@@ -102,21 +102,45 @@ public final class ModernAVPlayer: NSObject, ModernAVPlayerExposable {
     ///
     /// Sets the media current time to the specified position
     ///
-    /// - Note: position is bounded between 0 and end time or available ranges
+    /// - Note: position is bounded between 0 and end time or available ranges, resulting seek position may differ slightly for efficiency
     /// - parameter position: time to seek
     ///
     public func seek(position: Double) {
-        context.seek(position: position)
+        context.seek(position: position, isAccurate: false)
+    }
+    
+    ///
+    /// Sets the media current time to the specified position
+    ///
+    /// - Note: position is bounded between 0 and end time or available ranges
+    /// - parameter position: time to seek
+    /// - parameter isAccurate: pass true if you desire presice seeking, may incur additional decoding delay
+    /// which can impact seeking performance, default is false
+    ///
+    public func seek(position: Double, isAccurate: Bool = false) {
+        context.seek(position: position, isAccurate: isAccurate)
     }
 
     ///
     /// Apply offset to the media current time
     ///
-    /// - Note: this method compute position then call then seek(position:)
+    /// - Note: this method compute position then call then seek(position:), resulting seek position may differ slightly for efficiency
     /// - parameter offset: offset to apply
     ///
     public func seek(offset: Double) {
-        context.seek(offset: offset)
+        context.seek(offset: offset, isAccurate: false)
+    }
+    
+    ///
+    /// Apply offset to the media current time
+    ///
+    /// - Note: this method compute position then call then seek(position:), resulting seek position may differ slightly for efficiency
+    /// - parameter offset: offset to apply
+    /// - parameter isAccurate: pass true if you desire presice seeking,
+    /// may incur additional decoding delay which can impact seeking performance, default is false
+    ///
+    public func seek(offset: Double, isAccurate: Bool = false) {
+        context.seek(offset: offset, isAccurate: isAccurate)
     }
     
     /// Stops playback of the current item then seek to 0

--- a/Sources/Core/Services/RateObservingService.swift
+++ b/Sources/Core/Services/RateObservingService.swift
@@ -39,6 +39,7 @@ final class ModernAVPlayerRateObservingService: RateObservingService {
     // MARK: - Inputs
     
     private let item: AVPlayerItem
+    private let player: AVPlayer
     private let timeInterval: TimeInterval
     private let timeout: TimeInterval
     private let timerFactory: TimerFactory
@@ -55,12 +56,13 @@ final class ModernAVPlayerRateObservingService: RateObservingService {
 
     // MARK: - Lifecycle
     
-    init(config: PlayerConfiguration, item: AVPlayerItem, timerFactory: TimerFactory = ModernAVPlayerTimerFactory()) {
+    init(config: PlayerConfiguration, item: AVPlayerItem, timerFactory: TimerFactory = ModernAVPlayerTimerFactory(), player: AVPlayer) {
         ModernAVPlayerLogger.instance.log(message: "Init", domain: .lifecycleService)
         timeInterval = config.rateObservingTickTime
         timeout = config.rateObservingTimeout
         self.timerFactory = timerFactory
         self.item = item
+        self.player = player
     }
     
     deinit {
@@ -102,6 +104,8 @@ final class ModernAVPlayerRateObservingService: RateObservingService {
             timer?.invalidate()
             onTimeout?()
         } else {
+            //try to force play if playback stalled
+            player.play()
             ModernAVPlayerLogger.instance.log(message: "Remaining time: \(remainingTime)", domain: .service)
         }
     }

--- a/Sources/Core/State/BufferingState.swift
+++ b/Sources/Core/State/BufferingState.swift
@@ -49,7 +49,7 @@ final class BufferingState: NSObject, PlayerState {
         guard let item = context.currentItem else { fatalError("item should exist") }
         
         self.context = context
-        self.rateObservingService = rateObservingService ?? ModernAVPlayerRateObservingService(config: context.config, item: item)
+        self.rateObservingService = rateObservingService ?? ModernAVPlayerRateObservingService(config: context.config, item: item, player: context.player)
         self.interruptionAudioService = interruptionAudioService
         
         super.init()

--- a/Sources/Core/State/BufferingState.swift
+++ b/Sources/Core/State/BufferingState.swift
@@ -103,10 +103,12 @@ final class BufferingState: NSObject, PlayerState {
         context.player.play()
     }
 
-    func seekCommand(position: Double) {
+    func seekCommand(position: Double, isAccurate: Bool) {
         context.currentItem?.cancelPendingSeeks()
         let time = CMTime(seconds: position, preferredTimescale: context.config.preferredTimescale)
-        context.player.seek(to: time) { [weak self] completed in
+        let toleranceBefore: CMTime = isAccurate ? .zero : .positiveInfinity
+        let toleranceAfter: CMTime = isAccurate ? .zero : .positiveInfinity
+        context.player.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] completed in
             guard completed, let strongSelf = self else { return }
             strongSelf.context.delegate?.playerContext(didCurrentTimeChange: strongSelf.context.currentTime)
             strongSelf.playCommand()
@@ -130,8 +132,8 @@ final class BufferingState: NSObject, PlayerState {
         context.delegate?.playerContext(unavailableActionReason: .alreadyTryingToPlay)
     }
 
-    func seek(position: Double) {
-        seekCommand(position: position)
+    func seek(position: Double, isAccurate: Bool) {
+        seekCommand(position: position, isAccurate: isAccurate)
     }
 
     func stop() {

--- a/Sources/Core/State/BufferingState.swift
+++ b/Sources/Core/State/BufferingState.swift
@@ -106,9 +106,8 @@ final class BufferingState: NSObject, PlayerState {
     func seekCommand(position: Double, isAccurate: Bool) {
         context.currentItem?.cancelPendingSeeks()
         let time = CMTime(seconds: position, preferredTimescale: context.config.preferredTimescale)
-        let toleranceBefore: CMTime = isAccurate ? .zero : .positiveInfinity
-        let toleranceAfter: CMTime = isAccurate ? .zero : .positiveInfinity
-        context.player.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] completed in
+        let tolerance: CMTime = isAccurate ? .zero : .positiveInfinity
+        context.player.seek(to: time, toleranceBefore: tolerance, toleranceAfter: tolerance) { [weak self] completed in
             guard completed, let strongSelf = self else { return }
             strongSelf.context.delegate?.playerContext(didCurrentTimeChange: strongSelf.context.currentTime)
             strongSelf.playCommand()

--- a/Sources/Core/State/FailedState.swift
+++ b/Sources/Core/State/FailedState.swift
@@ -80,7 +80,7 @@ final class FailedState: PlayerState {
         context.changeState(state: state)
     }
 
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let debug = "Unable to seek, load a media first"
         ModernAVPlayerLogger.instance.log(message: debug, domain: .unavailableCommand)
         context.delegate?.playerContext(unavailableActionReason: .loadMediaFirst)

--- a/Sources/Core/State/InitState.swift
+++ b/Sources/Core/State/InitState.swift
@@ -64,7 +64,7 @@ struct InitState: PlayerState {
         context.delegate?.playerContext(unavailableActionReason: .loadMediaFirst)
     }
     
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let debug = "Load item before seeking"
         ModernAVPlayerLogger.instance.log(message: debug, domain: .unavailableCommand)
         context.delegate?.playerContext(unavailableActionReason: .loadMediaFirst)

--- a/Sources/Core/State/LoadedState.swift
+++ b/Sources/Core/State/LoadedState.swift
@@ -76,9 +76,8 @@ struct LoadedState: PlayerState {
 
     func seek(position: Double, isAccurate: Bool) {
         let time = CMTime(seconds: position, preferredTimescale: context.config.preferredTimescale)
-        let toleranceBefore: CMTime = isAccurate ? .zero : .positiveInfinity
-        let toleranceAfter: CMTime = isAccurate ? .zero : .positiveInfinity
-        context.player.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [context] completed in
+        let tolerance: CMTime = isAccurate ? .zero : .positiveInfinity
+        context.player.seek(to: time, toleranceBefore: tolerance, toleranceAfter: tolerance) { [context] completed in
             guard completed else { return }
             context.delegate?.playerContext(didCurrentTimeChange: context.currentTime)
             context.nowPlaying.overrideInfoCenter(for: MPNowPlayingInfoPropertyElapsedPlaybackTime,

--- a/Sources/Core/State/LoadedState.swift
+++ b/Sources/Core/State/LoadedState.swift
@@ -74,9 +74,11 @@ struct LoadedState: PlayerState {
         state.playCommand()
     }
 
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let time = CMTime(seconds: position, preferredTimescale: context.config.preferredTimescale)
-        context.player.seek(to: time) { [context] completed in
+        let toleranceBefore: CMTime = isAccurate ? .zero : .positiveInfinity
+        let toleranceAfter: CMTime = isAccurate ? .zero : .positiveInfinity
+        context.player.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [context] completed in
             guard completed else { return }
             context.delegate?.playerContext(didCurrentTimeChange: context.currentTime)
             context.nowPlaying.overrideInfoCenter(for: MPNowPlayingInfoPropertyElapsedPlaybackTime,

--- a/Sources/Core/State/LoadingMediaState.swift
+++ b/Sources/Core/State/LoadingMediaState.swift
@@ -113,7 +113,7 @@ final class LoadingMediaState: PlayerState {
         context.delegate?.playerContext(unavailableActionReason: .waitLoadedMedia)
     }
 
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let debug = "Wait media to be loaded before seeking"
         ModernAVPlayerLogger.instance.log(message: debug, domain: .unavailableCommand)
         context.delegate?.playerContext(unavailableActionReason: .waitLoadedMedia)

--- a/Sources/Core/State/PausedState.swift
+++ b/Sources/Core/State/PausedState.swift
@@ -94,9 +94,11 @@ class PausedState: PlayerState {
         }
     }
 
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let time = CMTime(seconds: position, preferredTimescale: context.config.preferredTimescale)
-        context.player.seek(to: time) { [weak self] completed in
+        let toleranceBefore: CMTime = isAccurate ? .zero : .positiveInfinity
+        let toleranceAfter: CMTime = isAccurate ? .zero : .positiveInfinity
+        context.player.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] completed in
             guard completed, let context = self?.context else { return }
             context.delegate?.playerContext(didCurrentTimeChange: context.currentTime)
             context.nowPlaying.overrideInfoCenter(for: MPNowPlayingInfoPropertyElapsedPlaybackTime,

--- a/Sources/Core/State/PausedState.swift
+++ b/Sources/Core/State/PausedState.swift
@@ -96,9 +96,8 @@ class PausedState: PlayerState {
 
     func seek(position: Double, isAccurate: Bool) {
         let time = CMTime(seconds: position, preferredTimescale: context.config.preferredTimescale)
-        let toleranceBefore: CMTime = isAccurate ? .zero : .positiveInfinity
-        let toleranceAfter: CMTime = isAccurate ? .zero : .positiveInfinity
-        context.player.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] completed in
+        let tolerance: CMTime = isAccurate ? .zero : .positiveInfinity
+        context.player.seek(to: time, toleranceBefore: tolerance, toleranceAfter: tolerance) { [weak self] completed in
             guard completed, let context = self?.context else { return }
             context.delegate?.playerContext(didCurrentTimeChange: context.currentTime)
             context.nowPlaying.overrideInfoCenter(for: MPNowPlayingInfoPropertyElapsedPlaybackTime,

--- a/Sources/Core/State/PlayingState.swift
+++ b/Sources/Core/State/PlayingState.swift
@@ -113,10 +113,10 @@ final class PlayingState: PlayerState {
         context.delegate?.playerContext(unavailableActionReason: .alreadyPlaying)
     }
 
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let state = BufferingState(context: context)
         changeState(state: state)
-        state.seekCommand(position: position)
+        state.seekCommand(position: position, isAccurate: isAccurate)
     }
 
     func stop() {
@@ -142,7 +142,7 @@ final class PlayingState: PlayerState {
                 $0.didItemPlayToEndTime(media: media, endTime: strongSelf.context.currentTime)
             }
             if strongSelf.context.loopMode {
-                strongSelf.seek(position: 0)
+                strongSelf.seek(position: 0, isAccurate: false)
             } else {
                 strongSelf.stop()
             }

--- a/Sources/Core/State/StoppedState.swift
+++ b/Sources/Core/State/StoppedState.swift
@@ -34,7 +34,7 @@ final class StoppedState: PausedState {
     init(context: PlayerContext) {
         super.init(context: context, type: .stopped)
 
-        seek(position: 0)
+        seek(position: 0, isAccurate: false)
     }
 
     override func contextUpdated() {

--- a/Sources/Core/State/WaitingNetworkState.swift
+++ b/Sources/Core/State/WaitingNetworkState.swift
@@ -110,7 +110,7 @@ final class WaitingNetworkState: PlayerState {
         context.delegate?.playerContext(unavailableActionReason: .waitEstablishedNetwork)
     }
     
-    func seek(position: Double) {
+    func seek(position: Double, isAccurate: Bool) {
         let debug = "Reload a media first before seeking"
         ModernAVPlayerLogger.instance.log(message: debug, domain: .unavailableCommand)
         context.delegate?.playerContext(unavailableActionReason: .waitEstablishedNetwork)


### PR DESCRIPTION
Feature: 
Add precise seek api that utilizes Apple's seek(to:tolearanceBefore:toleranceAfter:) 
~~~
seek(position: Double, isAccurate: Bool)
seek(offset: Double, isAccurate: Bool)
~~~

Tests are missing, had troubles with regenerating Mocks, I will appreciate if you can help me with this @raphrel 🙏